### PR TITLE
Fix screenshot image paths

### DIFF
--- a/physical_infra_provider_configuration/automation/topics/assigning_policy_profile.adoc
+++ b/physical_infra_provider_configuration/automation/topics/assigning_policy_profile.adoc
@@ -2,7 +2,7 @@
 
 You can assign policy profiles to physical infrastructure providers as shown below.
 
-image:../images/provider_assign_profile.png[]
+image:automation/images/provider_assign_profile.png[]
 
 . Navigate to Compute → Physical Infrastructure → Providers and select **(Providers).**
 

--- a/physical_infra_provider_configuration/usage/topics/adding_providers.adoc
+++ b/physical_infra_provider_configuration/usage/topics/adding_providers.adoc
@@ -28,4 +28,4 @@ The Physical Infrastructure Provider extends CloudForms management capabilities 
 
 Once added, providers can be viewed by navigating to *Compute → Physical Infrastructure → Providers* as shown below.
 
-image:../images/providers.png[]
+image:usage/images/providers.png[]

--- a/physical_infra_provider_configuration/usage/topics/performing_identify_operations.adoc
+++ b/physical_infra_provider_configuration/usage/topics/performing_identify_operations.adoc
@@ -2,4 +2,4 @@
 
 Similar to power operations, you can do some identify operations with your physical servers, to do that you just need to select the servers that you want to perform such operations, and look at the top left, at the right side of Power button, and find the Identify button, clickin it the operations  availables will be showed, select one of them to perform. See the screenshot below.
 
-image:../images/physical_server_identify_led.png[]
+image:usage/images/physical_server_identify_led.png[]

--- a/physical_infra_provider_configuration/usage/topics/performing_power_operations.adoc
+++ b/physical_infra_provider_configuration/usage/topics/performing_power_operations.adoc
@@ -2,4 +2,4 @@
 
 You can also perform some power operations to your servers. To do this, you need just to select the servers that you wish to perform such operations and look at the top left in the Power button, click it and see the operations availables: Power On, Power Off and Restart. As we can see in the screenshot below.
 
-image:../images/physical_server_power.png[]
+image:usage/images/physical_server_power.png[]

--- a/physical_infra_provider_configuration/usage/topics/provisioning_physical_servers.adoc
+++ b/physical_infra_provider_configuration/usage/topics/provisioning_physical_servers.adoc
@@ -2,7 +2,7 @@
 
 Physical servers can be provisioned using Lenovo XClarity Administrator (LXCA) configuration patterns. Configuration patterns can be thought of as templates that describe the configuration of servers. The Lenovo Physical Infrastructure Provider discovers configuration patterns that are defined on the LXCA instance that is associated with the provider. A pattern can then be applied to a single or multiple physical servers as shown below. _Note:_ Configuration patterns can only be assigned to servers that do not already have a pattern assigned to them.
 
-image:../images/physical_server_provision.png[]
+image:usage/images/physical_server_provision.png[]
 
 ===== Provisioning a Single Server
 

--- a/physical_infra_provider_configuration/usage/topics/using_topology_widgets.adoc
+++ b/physical_infra_provider_configuration/usage/topics/using_topology_widgets.adoc
@@ -2,7 +2,7 @@
 
 The Physical Infrastructure Provider has the ability to highlight the relationship between virtual hosts and physical servers each host leverages. The topology view provides a graphical representation of these relationships, allowing the administrator to easily navigate between connected components. A screenshot of this view is shown below.
 
-image:../images/topology_widget.png[]
+image:usage/images/topology_widget.png[]
 
 . Navigate to *Compute → Physical Infrastructure → Providers.*
 

--- a/physical_infra_provider_configuration/usage/topics/viewing_host_relationships.adoc
+++ b/physical_infra_provider_configuration/usage/topics/viewing_host_relationships.adoc
@@ -7,4 +7,4 @@ You can view Host-associated Physical Servers that belong to the provider. In or
 
 You should see a list with the Host-associated Physical Servers as shown in the screenshot below.
 
-image:../images/host_relationships.png[]
+image:usage/images/host_relationships.png[]

--- a/physical_infra_provider_configuration/usage/topics/viewing_physical_servers.adoc
+++ b/physical_infra_provider_configuration/usage/topics/viewing_physical_servers.adoc
@@ -4,4 +4,4 @@ To view your physical servers you just have to navigate through the sidebar by t
 
 And the page will look like the following, note that there is some options in the right top to change the way that your servers are listed, try it and see what is the best way for you.
 
-image:../images/physical_servers.png[]
+image:usage/images/physical_servers.png[]


### PR DESCRIPTION
This PR fixes the image paths of the screenshots, so they are rendered when a PDF is created from main.adoc.